### PR TITLE
fix: repair NodeNorm status test and refresh Babel expectations

### DIFF
--- a/tests/test_nodenorm.py
+++ b/tests/test_nodenorm.py
@@ -2,6 +2,12 @@ import pytest
 import TCT
 
 # Some example queries for these tests.
+#
+# NOTE: the expected `curie`/`label`/`biolink_type` values below are pinned to
+# the Translator NodeNorm service, which is backed by the NCATSTranslator/Babel
+# compendia. When Babel ships a new compendia release, preferred CURIEs, labels
+# (including casing) and categories can shift, so these expectations may need a
+# periodic refresh.
 EXAMPLE_QUERIES = [
     {
         'query': 'MESH:D003924',
@@ -13,9 +19,9 @@ EXAMPLE_QUERIES = [
     },
     {
         'query': 'UMLS:C0004096',
-        'curie': 'MONDO:0004979',
+        'curie': 'MONDO:0100470',
         'label_with_geneprotein_conflation': 'Asthma',
-        'label': 'asthma',
+        'label': 'Asthma',
         'biolink_type': 'biolink:Disease',
         'drug_chemical_conflate': True,
         'conflate': True,
@@ -31,10 +37,10 @@ EXAMPLE_QUERIES = [
     },
     {
         'query': 'DRUGBANK:DB00083',
-        'curie': 'UMLS:C0006050',
+        'curie': 'DRUGBANK:DB00083',
         'label_with_geneprotein_conflation': 'Botulinum toxin type A',
-        'label': 'Dysport',
-        'biolink_type': 'biolink:Protein',
+        'label': 'Botulinum toxin type A',
+        'biolink_type': 'biolink:ChemicalEntity',
         'drug_chemical_conflate': True,
         'conflate': True,
     },

--- a/tests/test_nodenorm.py
+++ b/tests/test_nodenorm.py
@@ -76,12 +76,15 @@ EXAMPLE_QUERIES = [
 def test_nodenorm_status():
     """
     Test that NodeNorm can return status information.
+
+    Note: unlike NameRes, the NodeNorm ``/status`` endpoint does not report a
+    ``babel_version`` (that compendia metadata lives on the NameRes status), so
+    we only assert the fields NodeNorm actually exposes: ``status`` and the
+    underlying database counts.
     """
     status = TCT.node_normalizer.status()
 
     assert status['status'] == 'running'
-    assert status['babel_version'] != ''
-    assert status['babel_version_url'] != ''
     assert status['databases']['eq_id_to_id_db']['count'] > 650_000_000
 
 


### PR DESCRIPTION
Fixes the four failing `tests/test_nodenorm.py` checks that were red on `main` and blocking unrelated PRs (e.g. #45). All four failures trace back to the live Translator services: the NodeNorm `/status` endpoint never exposed `babel_version`, and the Babel-backed compendia have drifted the preferred CURIEs, labels, and categories for two example queries.

### NodeNorm status test
- **Removed `babel_version` / `babel_version_url` assertions** from `test_nodenorm_status`. Unlike NameRes (`name-lookup.ci.transltr.io/status`), the NodeNorm `/status` response only reports `status` and `databases`; asserting those keys raised `KeyError: 'babel_version'`. The NameRes status test still asserts `babel_version` and continues to pass.
- **Kept the stable checks:** `status['status'] == 'running'` and `databases['eq_id_to_id_db']['count'] > 650_000_000`.

### Normalization expectations
- **`UMLS:C0004096` (asthma):** preferred CURIE `MONDO:0004979` → `MONDO:0100470`, label `asthma` → `Asthma`.
- **`DRUGBANK:DB00083` (botulinum toxin type A):** preferred CURIE `UMLS:C0006050` → `DRUGBANK:DB00083`, label `Dysport` → `Botulinum toxin type A`, category `biolink:Protein` → `biolink:ChemicalEntity`.

### Design
- **Accepted caveat:** `EXAMPLE_QUERIES` pins exact preferred CURIEs/labels/categories to the live Babel-backed NodeNorm, so these will drift again on the next compendia release. A comment now documents this so the next refresh is obvious. Relaxing to shape-only assertions would lose the characterization coverage these tests provide, so the pinned values were refreshed instead.
- **No source changes:** only `tests/test_nodenorm.py` is touched; `TCT/node_normalizer.py` and the NameRes tests are unchanged.

### Testing
- `uv run pytest tests/test_nodenorm.py --no-cov -q` → `11 passed in 17.04s`
- `uv run pytest tests/ --no-cov -q` → `47 passed, 1 skipped in 34.47s`
- `uv run ruff check tests/test_nodenorm.py` → `All checks passed!`
- Drifted values verified against the live endpoints (`nodenorm.transltr.io/get_normalized_nodes`) for `UMLS:C0004096` and `DRUGBANK:DB00083`.