### PR TITLE
feat: isolate visualization dependencies behind optional extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,16 @@ Users can check out the key function documentations here: [https://ncatstranslat
 Allowing users to select APIs, predicates according to the user's intention. <br>
 Parallel and fast querying of the selected APIs.<br>
 Providing reproducible results by setting constraints.<br>
-Facilitating exploration of knowledge graphs from both Translator ecosystem and user-defined APIs.<br>
-Connecting LLMs to translate queries into TRAPI.<br>
-Node identifier resolution, annotation, and neighborhood/path analysis tools.<br>
-Developer-friendly API wrappers for Traitspace/CURIE resolution, caching, and result parsing.<br>
-User API integration support.<br>
+Faciliting to explore knowledge graphs from both Translator ecosystem and user defined APIs.<br>
+Connecting large language models to convert user's questions into TRAPI queries. <br>
+Find the identifier given a name using name resolver<br>
+Annotate a node using node annotator<br>
+Explore knowledge graphs in Translator<br>
+Find neighbors in the Translator KGs for a given node <br>
+Find paths between node A and node B in the Translator KG <br>
+Find a subnetwork given a list of nodes in the Translator KG <br>
+Developer-friendly wrappers for resolving labels/CURIEs, caching Translator resources, and returning parsed finder results <br>
+Connecting user's API with Translator API <br>
 *Note: Visualization capabilities (pyvis, matplotlib, seaborn) can be installed separately via the `vision` extra.*
 
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,13 @@ pip install TCT
 # TCT is in development, to get the most recent update, user can install it through the github repo
 ```
 
-**This the recommended approach for installation.**
+**This is the recommended approach for a minimal installation.**
 
+Visualization support is optional. Install it with the `vision` extra when you need the plotting and graph-rendering utilities:
+
+```bash
+pip install "TCT[vision]"
+```
 
 #### Development Installation
 
@@ -51,6 +56,12 @@ pip install -e .
 git clone https://github.com/NCATSTranslator/Translator_component_toolkit.git
 cd Translator_component_toolkit
 uv sync
+```
+
+To include visualization support in the UV environment:
+
+```bash
+uv sync --extra vision
 ```
 
 #### Building and Deployment

--- a/README.md
+++ b/README.md
@@ -11,16 +11,12 @@ Users can check out the key function documentations here: [https://ncatstranslat
 Allowing users to select APIs, predicates according to the user's intention. <br>
 Parallel and fast querying of the selected APIs.<br>
 Providing reproducible results by setting constraints.<br>
-Faciliting to explore knowledge graphs from both Translator ecosystem and user defined APIs.<br>
-Connecting large language models to convert user's questions into TRAPI queries. <br>
-Find the identifier given a name using name resolver<br>
-Annotate a node using node annotator<br>
-Explore knowledge graphs in Translator<br>
-Find neighbors in the Translator KGs for a given node <br>
-Find paths between node A and node B in the Translator KG <br>
-Find a subnetwork given a list of nodes in the Translator KG <br>
-Developer-friendly wrappers for resolving labels/CURIEs, caching Translator resources, and returning parsed finder results <br>
-Connecting user's API with Translator API <br>
+Facilitating exploration of knowledge graphs from both Translator ecosystem and user-defined APIs.<br>
+Connecting LLMs to translate queries into TRAPI.<br>
+Node identifier resolution, annotation, and neighborhood/path analysis tools.<br>
+Developer-friendly API wrappers for Traitspace/CURIE resolution, caching, and result parsing.<br>
+User API integration support.<br>
+*Note: Visualization capabilities (pyvis, matplotlib, seaborn) can be installed separately via the `vision` extra.*
 
 
 ## How to use TCT

--- a/TCT/TCT.py
+++ b/TCT/TCT.py
@@ -4,16 +4,11 @@ from typing import Any, Optional, TypeAlias, Union
 import requests
 import json
 import pandas as pd
-import  seaborn as sns
-import matplotlib.pyplot as plt
-import networkx as nx
 import numpy as np
 #import openai
 from . import name_resolver, node_normalizer, translator_query
 
 # plt.switch_backend('module://ipykernel.pylab.backend_inline')
-
-from IPython.display import display
 
 __all__ = [
     'TCT_help',
@@ -851,6 +846,9 @@ def plot_heatmap(predicates_by_nodes_df,num_of_nodes = 20,
                                  fontsize = 6,
                                  title_fontsize = 10,
                                  output_png="NE_heatmap.png"):
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     #matplotlib.use('Agg')
 
     #title = "Ranking of one-hop nodes by primary infores"
@@ -891,7 +889,8 @@ def plot_heatmap_ui(predicates_by_nodes_df,num_of_nodes = 20,
                                  fontsize = 6,
                                  title_fontsize = 10,
                                  output_png="NE_heatmap.png"):
-
+    import matplotlib.pyplot as plt
+    import seaborn as sns
 
     title = "Ranking of one-hop nodes by primary infores"
     ylab = "infores"
@@ -1658,7 +1657,8 @@ def merge_by_ranking_index(result_ranked_by_primary_infores,
                            title_fontsize = 12,
                            fontsize = 12,
                            ):
-
+    import matplotlib.pyplot as plt
+    import seaborn as sns
 
     dic_rank1 = {}
     for i in range(0, result_ranked_by_primary_infores.shape[0]):
@@ -1774,6 +1774,9 @@ def plot_path_bar(x,
                     fontsize = 8,
                     title_fontsize = 10,
                     output_png="NE_heatmap.png"):
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     #matplotlib.use('Agg')
 
     # title = "Bridging nodes"  # Unused variable
@@ -1965,6 +1968,9 @@ def select_result_to_analysis(sele_genes,Temp_result_df1, Temp_result_df2 ):
 
 
 def plot_graph_by_predicates(for_plot):
+    import networkx as nx
+    from IPython.display import display
+
     graph = nx.from_pandas_edgelist(for_plot,
                                 source='Subject',
                                 target='Object',
@@ -2013,6 +2019,8 @@ def plot_graph_by_predicates(for_plot):
 
 
 def plot_graph_by_infores(for_plot):
+    import networkx as nx
+    from IPython.display import display
 
     graph = nx.from_pandas_edgelist(for_plot,
                                     source='Subject',
@@ -2062,6 +2070,8 @@ def plot_graph_by_infores(for_plot):
 
 
 def plot_graph_by_API(for_plot):
+    import networkx as nx
+    from IPython.display import display
 
     graph = nx.from_pandas_edgelist(for_plot,
                                     source='Subject',
@@ -2273,6 +2283,9 @@ def load_translator_resources():
 
 
 def visulize_path(input_node1_id, intermediate_node, input_node3_id, result, result2):
+    import networkx as nx
+    from IPython.display import display
+
     forplot_subject = []
     forplot_object = []
     forplot_predicate = []

--- a/TCT/TCT_Visualization.py
+++ b/TCT/TCT_Visualization.py
@@ -1,9 +1,6 @@
 
 from .node_normalizer import ID_convert_to_preferred_name_nodeNormalizer
 
-import networkx as nx
-from pyvis.network import Network
-
 def visualize_neighborhood_graph(result, show_label=True, height="1000px", width="100%", output_filename_prefix=None):
     '''Visualize the neighborhood graph using pyvis
     Args:
@@ -18,6 +15,9 @@ def visualize_neighborhood_graph(result, show_label=True, height="1000px", width
         dic_graph = visualize_neighborhood_graph(result, show_label=True, height="500", width="100%")
     '''
     
+    import networkx as nx
+    from pyvis.network import Network
+
     # Your JSON (as Python dict)
     data = result
     IDs = []

--- a/docs/source/intro.md
+++ b/docs/source/intro.md
@@ -23,7 +23,17 @@ Guangrong Qin, guangrong.qin@isbscience.org
 ## How to use TCT
 ### Install Requirements
 
-To install TCT as a python library, you can install the library using `pip install TCT` from the command line. 
+To install the minimal TCT package, run:
+
+```bash
+pip install TCT
+```
+
+Visualization support is optional. Install it with the `vision` extra when you need the plotting and graph-rendering utilities:
+
+```bash
+pip install "TCT[vision]"
+```
 
 The TCT is continuously updated, if you would like to use the latest functions, you can also  clone this most recent github repository (https://github.com/NCATSTranslator/Translator_component_toolkit/tree/main), 
 `git clone https://github.com/NCATSTranslator/Translator_component_toolkit.git`

--- a/docs/source/intro.md
+++ b/docs/source/intro.md
@@ -12,6 +12,7 @@ Allowing testing whether a user defined API follows a [TRAPI](https://github.com
 Faciliting to explore knowledge graphs from both Translator ecosystem and user defined APIs.<br>
 Developer-friendly `pathfinder` and `neighborhood_finder` wrappers for resolving labels/CURIEs, caching Translator resources, and returning parsed finder results (`from TCT import pathfinder, neighborhood_finder`). <br>
 Connecting large language models to convert user's questions into TRAPI queries. <br>
+*Note: Visualization capabilities (pyvis, matplotlib, seaborn) can be installed via the `vision` extra using `pip install TCT[vision]`*
 
 ### Contributing
 TCT is a tool that helps to explore knowledge graphs developed in the Biomedical Data Translator Consortium. Consortium members and external contributors are encouraged to submit issues and pull requests. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,18 +24,20 @@ dependencies = [
     "requests",
     "jsons",
     "pandas",
-    "seaborn",
-    "matplotlib",
     "ipycytoscape",
     "networkx",
     "numpy",
     "openai",
     "ipykernel",
-    'networkx',
-    'igraph',
-    'pyvis',
-    'zstandard',
+    "igraph",
+    "zstandard",
 ]
+
+[project.extras.vision]
+"""Visualization dependencies."""
+pyvis = "pyvis"
+matplotlib = "matplotlib"
+seaborn = "seaborn"
 
 [project.optional-dependencies]
 mcp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,6 @@ dependencies = [
     "requests",
     "jsons",
     "pandas",
-    "ipycytoscape",
-    "networkx",
     "numpy",
     "openai",
     "ipykernel",
@@ -33,13 +31,14 @@ dependencies = [
     "zstandard",
 ]
 
-[project.extras.vision]
-"""Visualization dependencies."""
-pyvis = "pyvis"
-matplotlib = "matplotlib"
-seaborn = "seaborn"
-
 [project.optional-dependencies]
+vision = [
+    "ipycytoscape",
+    "matplotlib",
+    "networkx",
+    "pyvis",
+    "seaborn",
+]
 mcp = [
     "fastmcp>=2.12.2",
     "click>=8.2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -2788,19 +2788,13 @@ version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "igraph" },
-    { name = "ipycytoscape" },
     { name = "ipykernel" },
     { name = "jsons" },
-    { name = "matplotlib" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "pandas" },
-    { name = "pyvis" },
     { name = "requests" },
-    { name = "seaborn" },
     { name = "zstandard" },
 ]
 
@@ -2808,6 +2802,14 @@ dependencies = [
 mcp = [
     { name = "click" },
     { name = "fastmcp" },
+]
+vision = [
+    { name = "ipycytoscape" },
+    { name = "matplotlib" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyvis" },
+    { name = "seaborn" },
 ]
 
 [package.dev-dependencies]
@@ -2824,20 +2826,20 @@ requires-dist = [
     { name = "click", marker = "extra == 'mcp'", specifier = ">=8.2.1" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.12.2" },
     { name = "igraph" },
-    { name = "ipycytoscape" },
+    { name = "ipycytoscape", marker = "extra == 'vision'" },
     { name = "ipykernel" },
     { name = "jsons" },
-    { name = "matplotlib" },
-    { name = "networkx" },
+    { name = "matplotlib", marker = "extra == 'vision'" },
+    { name = "networkx", marker = "extra == 'vision'" },
     { name = "numpy" },
     { name = "openai" },
     { name = "pandas" },
-    { name = "pyvis" },
+    { name = "pyvis", marker = "extra == 'vision'" },
     { name = "requests" },
-    { name = "seaborn" },
+    { name = "seaborn", marker = "extra == 'vision'" },
     { name = "zstandard" },
 ]
-provides-extras = ["mcp"]
+provides-extras = ["vision", "mcp"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Moves visualization-only dependencies out of TCT's minimal installation and documents the opt-in installation path. The base package can now be installed without pulling plotting and graph-rendering packages.

### Optional Visualization Dependencies

- **`vision` extra:** Moves `ipycytoscape`, `matplotlib`, `networkx`, `pyvis`, and `seaborn` into `[project.optional-dependencies].vision`.
- **Lazy imports:** Loads visualization libraries only when visualization functions are called, preserving base-package imports without those dependencies.
- **Lockfile:** Regenerates `uv.lock` with the new optional dependency markers.

### Documentation

- **Minimal install:** Documents `pip install TCT`.
- **Visualization install:** Documents `pip install "TCT[vision]"` and `uv sync --extra vision` in `README.md` and `docs/source/intro.md`.

### Testing

- `uv lock --check` — passed.
- `uv run --extra mcp pytest -q` — `58 passed, 1 skipped`.
- `uv build --out-dir /tmp/tct-dist-check` — wheel and source distribution built successfully.
- Base import guarded against visualization imports — passed.
- Sphinx CI run — passed: [run #31650717890](https://github.com/NCATSTranslator/Translator_component_toolkit/actions/runs/31650717890).
- `uv run ruff check TCT tests` — existing repository findings remain; CI lint is non-blocking.
